### PR TITLE
Add optional ECR push to docker workflow (v1)

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -30,10 +30,33 @@ on:
         type: string
         # Define array as string because Github does not support arrays here at the moment
         default: "['production']"
+      ecr:
+        description: Also build-push to AWS ECR (single build, multi-registry)
+        required: false
+        type: boolean
+        default: false
+      aws-region:
+        description: AWS region of the ECR registry
+        required: false
+        type: string
+        default: eu-west-1
+      aws-role-arn:
+        description: IAM role ARN to assume for ECR push (OIDC, no static keys)
+        required: false
+        type: string
+        default: ''
+      ecr-repository:
+        description: ECR repository name (defaults to imageName / repo name)
+        required: false
+        type: string
+        default: ''
 
 jobs:
   main:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write   # OIDC: assume the ECR push role (only used when ecr=true)
+      contents: read
     strategy:
       matrix:
         target: ${{ fromJson(inputs.targets) }}
@@ -47,6 +70,19 @@ jobs:
           username: ${{ secrets.DockerHubUser }}
           password: ${{ secrets.DockerHubPass }}
       ######################################################
+      # ECR auth (OIDC) — only when ecr=true
+      ######################################################
+      - name: Configure AWS credentials
+        if: ${{ inputs.ecr }}
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ inputs.aws-role-arn }}
+          aws-region: ${{ inputs.aws-region }}
+      - name: Login to Amazon ECR
+        id: ecr
+        if: ${{ inputs.ecr }}
+        uses: aws-actions/amazon-ecr-login@v2
+      ######################################################
       # Setting up final build tags
       ######################################################
       - name: Prepare Tags
@@ -54,12 +90,19 @@ jobs:
         run: |
           IMAGE=elbgoodsgmbh/${{ inputs.imageName != '' && inputs.imageName || github.event.repository.name }}
           echo "image=$IMAGE" >> $GITHUB_OUTPUT
+          ECR_REPO='${{ inputs.ecr-repository }}'
+          [ -z "$ECR_REPO" ] && ECR_REPO='${{ inputs.imageName != '' && inputs.imageName || github.event.repository.name }}'
+          echo "ecr_image=${{ steps.ecr.outputs.registry }}/${ECR_REPO}" >> $GITHUB_OUTPUT
 
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ steps.prep.outputs.image }}
+          # Multi-registry: metadata-action emits the same tag set for each image,
+          # so the single build below pushes to Docker Hub AND ECR — no second build.
+          images: |
+            ${{ steps.prep.outputs.image }}
+            ${{ inputs.ecr && steps.prep.outputs.ecr_image || '' }}
           flavor: |
             latest=false
           tags: |
@@ -68,12 +111,15 @@ jobs:
             type=semver,pattern={{version}},enable=${{ matrix.target == 'production' }}
 
             type=ref,event=branch
-            
+
             type=edge,branch=$repo.default_branch,enable=${{ matrix.target != 'development' }}
             type=edge,branch=$repo.default_branch,enable=${{ matrix.target == 'production' }}
 
             type=raw,value=${{ matrix.target }},enable=${{ matrix.target == 'development' || matrix.target == 'test' }}
             type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'main') && matrix.target == 'production' }}
+
+            # ECR-only: sha-prefixed tag for Flux image-automation (dev sha-* bumps).
+            type=sha,prefix=sha-,enable=${{ inputs.ecr && matrix.target == 'production' }}
 
       ######################################################
       # Setup Cache and BuildX


### PR DESCRIPTION
## What
Ports the **opt-in** AWS ECR push onto the `release/v1` workflow (the matrix/`targets` version that callers pin via `@v1` / `@release/v1`). Single build, multi-registry — no second build per registry.

Companion to #5 (same change on `main`). Only the ECR bits are added here — the matrix `targets`, `imageName`/`dockerFile`, checkout@v6, per-target tag scheme and sentry build-args are untouched (+48/-2).

## Why
Crewzone service images need to land in ECR for the AWS EKS cluster without dual-building one image per registry. `metadata-action` emits the same tag set for the Docker Hub and ECR images, and the existing single `build-push-action` pushes the one built image to both.

## How
New `workflow_call` inputs (all default off / backwards-compatible):

| input | default | purpose |
|---|---|---|
| `ecr` | `false` | enable the ECR push |
| `aws-region` | `eu-west-1` | ECR registry region |
| `aws-role-arn` | `''` | IAM role to assume (OIDC, no static keys) |
| `ecr-repository` | `''` | ECR repo name (defaults to `imageName` / repo name) |

When `ecr: true` (in the `main` job):
- `id-token: write` + `configure-aws-credentials` + `amazon-ecr-login` (OIDC)
- ECR image added to `metadata-action` `images:`
- `type=sha,prefix=sha-` added for the `production` target (feeds Flux image-automation)

`local`, `check-org`, `publish-sentry` jobs unchanged.

## Caller example
```yaml
jobs:
  docker:
    uses: elbgoods/public-workflows/.github/workflows/docker.yml@v1
    permissions:
      id-token: write
      contents: read
    with:
      ecr: true
      aws-role-arn: arn:aws:iam::681885730032:role/crewzone-ecr-ci
      ecr-repository: accounts-api   # only if image name != ECR repo name
    secrets: inherit
```

The `crewzone-ecr-ci` IAM role (OIDC trust for `elbgoods/*` main+tags, scoped ECR push) is provisioned in the crewzone-cluster CDK.