### PR TITLE
ECR-only + rentman tag scheme

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -117,17 +117,22 @@ jobs:
           flavor: |
             latest=false
           tags: |
-            # Default scheme (tagScheme != 'rentman')
-            type=semver,pattern={{version}},suffix=-staging,enable=${{ inputs.tagScheme != 'rentman' && matrix.target == 'staging' && github.event_name == 'release' }}
-            type=semver,pattern={{version}},suffix=-test,enable=${{ inputs.tagScheme != 'rentman' && matrix.target == 'test' && github.event_name == 'release' }}
-            type=semver,pattern={{version}},enable=${{ inputs.tagScheme != 'rentman' && matrix.target == 'production' }}
-            type=ref,event=branch,enable=${{ inputs.tagScheme != 'rentman' }}
-            type=edge,branch=$repo.default_branch,enable=${{ inputs.tagScheme != 'rentman' && matrix.target != 'development' }}
-            type=raw,value=${{ matrix.target }},enable=${{ inputs.tagScheme != 'rentman' && (matrix.target == 'development' || matrix.target == 'test') }}
-            type=raw,value=latest,enable=${{ inputs.tagScheme != 'rentman' && github.ref == format('refs/heads/{0}', 'main') && matrix.target == 'production' }}
-            type=sha,prefix=sha-,enable=${{ inputs.tagScheme != 'rentman' && inputs.ecr && matrix.target == 'production' }}
+            # Existing scheme — ALWAYS emitted (keeps Docker Hub / legacy deploys working)
+            type=semver,pattern={{version}},suffix=-staging,enable=${{ matrix.target == 'staging' && github.event_name == 'release' }}
+            type=semver,pattern={{version}},suffix=-test,enable=${{ matrix.target == 'test' && github.event_name == 'release' }}
+            type=semver,pattern={{version}},enable=${{ matrix.target == 'production' }}
 
-            # rentman scheme (per-env baked images): rentman-main / rentman-{ver}-staging / -production
+            type=ref,event=branch
+
+            type=edge,branch=$repo.default_branch,enable=${{ matrix.target != 'development' }}
+            type=edge,branch=$repo.default_branch,enable=${{ matrix.target == 'production' }}
+
+            type=raw,value=${{ matrix.target }},enable=${{ matrix.target == 'development' || matrix.target == 'test' }}
+            type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'main') && matrix.target == 'production' }}
+
+            type=sha,prefix=sha-,enable=${{ inputs.ecr && matrix.target == 'production' }}
+
+            # rentman scheme — ADDITIVE extra tags (opt-in via tagScheme=rentman) for the new cluster
             type=raw,value=rentman-main,enable=${{ inputs.tagScheme == 'rentman' && matrix.target == 'development' && github.ref == format('refs/heads/{0}', 'main') }}
             type=semver,pattern=rentman-{{version}}-staging,enable=${{ inputs.tagScheme == 'rentman' && matrix.target == 'staging' && github.event_name == 'release' }}
             type=semver,pattern=rentman-{{version}}-production,enable=${{ inputs.tagScheme == 'rentman' && matrix.target == 'production' && github.event_name == 'release' }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -4,9 +4,9 @@ on:
   workflow_call:
     secrets:
       DockerHubUser:
-        required: true
+        required: false
       DockerHubPass:
-        required: true
+        required: false
       ComposerAuth:
         required: false
       SentryToken:
@@ -50,6 +50,16 @@ on:
         required: false
         type: string
         default: ''
+      dockerHub:
+        description: Push to Docker Hub. Set false for ECR-only builds.
+        required: false
+        type: boolean
+        default: true
+      tagScheme:
+        description: "Tag scheme. 'rentman' = rentman-main / rentman-{ver}-staging / -production."
+        required: false
+        type: string
+        default: ''
 
 jobs:
   main:
@@ -65,6 +75,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Docker Login
+        if: ${{ inputs.dockerHub }}
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DockerHubUser }}
@@ -101,25 +112,25 @@ jobs:
           # Multi-registry: metadata-action emits the same tag set for each image,
           # so the single build below pushes to Docker Hub AND ECR — no second build.
           images: |
-            ${{ steps.prep.outputs.image }}
+            ${{ inputs.dockerHub && steps.prep.outputs.image || '' }}
             ${{ inputs.ecr && steps.prep.outputs.ecr_image || '' }}
           flavor: |
             latest=false
           tags: |
-            type=semver,pattern={{version}},suffix=-staging,enable=${{ matrix.target == 'staging' && github.event_name == 'release' }}
-            type=semver,pattern={{version}},suffix=-test,enable=${{ matrix.target == 'test' && github.event_name == 'release' }}
-            type=semver,pattern={{version}},enable=${{ matrix.target == 'production' }}
+            # Default scheme (tagScheme != 'rentman')
+            type=semver,pattern={{version}},suffix=-staging,enable=${{ inputs.tagScheme != 'rentman' && matrix.target == 'staging' && github.event_name == 'release' }}
+            type=semver,pattern={{version}},suffix=-test,enable=${{ inputs.tagScheme != 'rentman' && matrix.target == 'test' && github.event_name == 'release' }}
+            type=semver,pattern={{version}},enable=${{ inputs.tagScheme != 'rentman' && matrix.target == 'production' }}
+            type=ref,event=branch,enable=${{ inputs.tagScheme != 'rentman' }}
+            type=edge,branch=$repo.default_branch,enable=${{ inputs.tagScheme != 'rentman' && matrix.target != 'development' }}
+            type=raw,value=${{ matrix.target }},enable=${{ inputs.tagScheme != 'rentman' && (matrix.target == 'development' || matrix.target == 'test') }}
+            type=raw,value=latest,enable=${{ inputs.tagScheme != 'rentman' && github.ref == format('refs/heads/{0}', 'main') && matrix.target == 'production' }}
+            type=sha,prefix=sha-,enable=${{ inputs.tagScheme != 'rentman' && inputs.ecr && matrix.target == 'production' }}
 
-            type=ref,event=branch
-
-            type=edge,branch=$repo.default_branch,enable=${{ matrix.target != 'development' }}
-            type=edge,branch=$repo.default_branch,enable=${{ matrix.target == 'production' }}
-
-            type=raw,value=${{ matrix.target }},enable=${{ matrix.target == 'development' || matrix.target == 'test' }}
-            type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'main') && matrix.target == 'production' }}
-
-            # ECR-only: sha-prefixed tag for Flux image-automation (dev sha-* bumps).
-            type=sha,prefix=sha-,enable=${{ inputs.ecr && matrix.target == 'production' }}
+            # rentman scheme (per-env baked images): rentman-main / rentman-{ver}-staging / -production
+            type=raw,value=rentman-main,enable=${{ inputs.tagScheme == 'rentman' && matrix.target == 'development' && github.ref == format('refs/heads/{0}', 'main') }}
+            type=semver,pattern=rentman-{{version}}-staging,enable=${{ inputs.tagScheme == 'rentman' && matrix.target == 'staging' && github.event_name == 'release' }}
+            type=semver,pattern=rentman-{{version}}-production,enable=${{ inputs.tagScheme == 'rentman' && matrix.target == 'production' && github.event_name == 'release' }}
 
       ######################################################
       # Setup Cache and BuildX
@@ -154,7 +165,7 @@ jobs:
 
   local:
     runs-on: ubuntu-latest
-    if: github.ref_name == 'main' && inputs.buildLocal == true
+    if: github.ref_name == 'main' && inputs.buildLocal == true && inputs.dockerHub == true
     needs: main
     steps:
       - name: Checkout


### PR DESCRIPTION
Adds `dockerHub` (default true; false = ECR-only) and `tagScheme: rentman` (rentman-main / rentman-{ver}-staging / -production) for per-env SPA images. Defaults unchanged.