### PR TITLE
Cache buildx layers only on default-branch builds

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -153,8 +153,10 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
-          cache-from: "type=gha"
-          cache-to: "type=gha,mode=max"
+          # Cache only on default-branch builds — tag/release builds produce a unique
+          # cache key that is never reused, so caching them just wastes storage/time.
+          cache-from: ${{ github.ref == format('refs/heads/{0}', github.event.repository.default_branch) && 'type=gha' || '' }}
+          cache-to: ${{ github.ref == format('refs/heads/{0}', github.event.repository.default_branch) && 'type=gha,mode=max' || '' }}
           builder: ${{ steps.buildx.outputs.name }}
           file: ${{ inputs.dockerFile }}
           target: ${{ matrix.target }}


### PR DESCRIPTION
Enables gha cache only for default-branch builds; tag/release builds skip caching to avoid wasted single-use cache keys.