### PR TITLE
Fix :edge tag emission for dev deploys

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -124,8 +124,10 @@ jobs:
 
             type=ref,event=branch
 
-            type=edge,branch=$repo.default_branch,enable=${{ matrix.target != 'development' }}
-            type=edge,branch=$repo.default_branch,enable=${{ matrix.target == 'production' }}
+            # `type=edge` with branch=$repo.default_branch did not emit the tag here, so
+            # force it as a raw tag on default-branch production builds (same gate as latest).
+            # The :edge tag is what the dev cluster's argocd-image-updater watches.
+            type=raw,value=edge,enable=${{ github.ref == format('refs/heads/{0}', 'main') && matrix.target == 'production' }}
 
             type=raw,value=${{ matrix.target }},enable=${{ matrix.target == 'development' || matrix.target == 'test' }}
             type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'main') && matrix.target == 'production' }}


### PR DESCRIPTION
## Problem
Dev cluster stopped redeploying images (accounts-login-api reported, but affects all repos using `docker.yml@release/v1`). Build action goes green, but new image never rolls out.

Root cause: the workflow no longer pushes an `:edge` tag. Recent main-branch builds emit only `:main`, `:latest`, `:sha-<short>`:
```
"tag-names":["main","latest","sha-46a557c"]
```
The `type=edge,branch=$repo.default_branch` taggers did not resolve/emit an `edge` tag. The dev `argocd-image-updater` (prg-cluster `prg-dev`) watches `elbgoodsgmbh/<repo>:edge` with `update-strategy: digest`, so with no fresh `:edge` digest there is nothing to roll out.

## Fix
Replace the two non-firing `type=edge` lines with a raw `edge` tag gated exactly like `latest` (default branch + production target), so `:edge` is published again on every main build.

## Verify
After merge, trigger a main build and confirm `tag-names` includes `edge` and Docker Hub `:edge` digest updates; dev should redeploy.